### PR TITLE
Updates from Tuesday

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,3 @@ This is an initial staging area to develop two projects.
 
 1. An implementation of interceptors for the Python version of gRPC. (This [ticket](https://github.com/grpc/grpc/issues/8767)).
 2. Python gRPC interceptors that implement open-tracing.
-
-The code organized in the following way:
-
-py/ <- A python implementation of gRPC interceptors and a OpenTracing interceptors
-example/proto/ <- A simple proto file describing a service that returns a quantity for a given itemid.
-example/go/ <- A go implementation of the service using OpenTracing
-example/py/ <- A Python implementation of the service using OpenTracing

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,24 @@
+* **Add a tracer interceptor for synchronous calls on the server-side.**
+
+* **Add the ability to customize the method of obtaining a parent span in client-side interceptors.**
+
+* **Redesign interceptor interface to support asynchronous and batch RPC calls.**
+An interceptor interface like
+```python
+  def __call__(self, method, request, metadata, invoker):
+    …
+```
+won’t work for the batch versions where multiple requests are sent at once. I’ll probably do something similar to what’s done for Go which distinguishes between [unary](https://godoc.org/google.golang.org/grpc#WithUnaryInterceptor) and [stream](https://godoc.org/google.golang.org/grpc#WithStreamInterceptor) interceptors. We may also want some way to distinguish an intercepted synchronous call from an intercepted asynchronous call.
+
+* **Add interceptors for the async and batch RPC calls for both the client-side and the server-side.**
+
+* **Add utility functions that can chain multiple interceptors.** The plan in to make something similar to this [function](http://www.grpc.io/grpc-java/javadoc/io/grpc/ClientInterceptors.html#intercept-io.grpc.Channel-java.util.List-) for the client-side and this [function](http://www.grpc.io/grpc-java/javadoc/io/grpc/ServerInterceptors.html#intercept-io.grpc.ServerServiceDefinition-io.grpc.ServerInterceptor...-) on there server-side.
+
+* **Move interceptor code into the gRPC repository.**
+
+* **Add coverage for the interceptor code into gRPC’s unit testing framework.** The tests will need to fit somewhere in [here](https://github.com/grpc/grpc/tree/master/src/python/grpcio_tests/tests).
+
+* **Move the tracer interceptor code into the grpc-ecosystem repository.**
+
+* **Add test coverage for the tracer interceptors.**
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,9 @@
 * **Add a tracer interceptor for synchronous calls on the server-side.**
 
-* **Add the ability to customize the method of obtaining a parent span in client-side interceptors.**
+* **Add the ability to customize the method of obtaining a parent span in the
+  client-side tracer interceptor.**
 
-* **Redesign interceptor interface to support asynchronous and batch RPC calls.**
+* **Redesign the interceptor interface to support asynchronous and batch RPC calls.**
 An interceptor interface like
 ```python
   def __call__(self, method, request, metadata, invoker):

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@ wonâ€™t work for the batch versions where multiple requests are sent at once. Iâ
 
 * **Add interceptors for the async and batch RPC calls for both the client-side and the server-side.**
 
-* **Add utility functions that can chain multiple interceptors.** The plan in to make something similar to this [function](http://www.grpc.io/grpc-java/javadoc/io/grpc/ClientInterceptors.html#intercept-io.grpc.Channel-java.util.List-) for the client-side and this [function](http://www.grpc.io/grpc-java/javadoc/io/grpc/ServerInterceptors.html#intercept-io.grpc.ServerServiceDefinition-io.grpc.ServerInterceptor...-) on there server-side.
+* **Add utility functions that can chain multiple interceptors.** The plan in to make something similar to this [function](http://www.grpc.io/grpc-java/javadoc/io/grpc/ClientInterceptors.html#intercept-io.grpc.Channel-java.util.List-) for the client-side and this [function](http://www.grpc.io/grpc-java/javadoc/io/grpc/ServerInterceptors.html#intercept-io.grpc.ServerServiceDefinition-io.grpc.ServerInterceptor...-) on the server-side.
 
 * **Move interceptor code into the gRPC repository.**
 

--- a/example/go/client/main.go
+++ b/example/go/client/main.go
@@ -4,18 +4,18 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
-  "flag"
-  "fmt"
-  "os"
+	"os"
 
 	pb "../store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
-  "github.com/opentracing/opentracing-go"
-  "github.com/lightstep/lightstep-tracer-go"
-  "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/lightstep/lightstep-tracer-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 const (
@@ -25,26 +25,26 @@ const (
 var accessToken = flag.String("access_token", "", "your LightStep access token")
 
 func main() {
-  flag.Parse()
-  if len(*accessToken) == 0 {
-    fmt.Println("You must specify --access_token")
-    os.Exit(1)
-  }
+	flag.Parse()
+	if len(*accessToken) == 0 {
+		fmt.Println("You must specify --access_token")
+		os.Exit(1)
+	}
 
-  // Set up the LightStep tracer
-  tracerOpts := lightstep.Options{
-    AccessToken : *accessToken,
-  }
-  tracerOpts.Tags = make(opentracing.Tags)
-  tracerOpts.Tags["lightstep.component_name"] = "go.store-client"
-  tracer := lightstep.NewTracer(tracerOpts)
+	// Set up the LightStep tracer
+	tracerOpts := lightstep.Options{
+		AccessToken: *accessToken,
+	}
+	tracerOpts.Tags = make(opentracing.Tags)
+	tracerOpts.Tags["lightstep.component_name"] = "go.store-client"
+	tracer := lightstep.NewTracer(tracerOpts)
 
 	// Set up a connection to the server.
 	conn, err := grpc.Dial(
-    address, 
-    grpc.WithInsecure(),
-    grpc.WithUnaryInterceptor(
-      otgrpc.OpenTracingClientInterceptor(tracer)))
+		address,
+		grpc.WithInsecure(),
+		grpc.WithUnaryInterceptor(
+			otgrpc.OpenTracingClientInterceptor(tracer)))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
@@ -59,9 +59,9 @@ func main() {
 	}
 	log.Printf("Quantity: %d", r.Quantity)
 
-  // Force a flush of the tracer
-  err = lightstep.FlushLightStepTracer(tracer)
-  if err != nil {
-    panic(err)
-  }
+	// Force a flush of the tracer
+	err = lightstep.FlushLightStepTracer(tracer)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/example/go/client/main.go
+++ b/example/go/client/main.go
@@ -5,19 +5,46 @@ package main
 
 import (
 	"log"
+  "flag"
+  "fmt"
+  "os"
 
 	pb "../store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
+  "github.com/opentracing/opentracing-go"
+  "github.com/lightstep/lightstep-tracer-go"
+  "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 )
 
 const (
 	address = "localhost:50051"
 )
 
+var accessToken = flag.String("access_token", "", "your LightStep access token")
+
 func main() {
+  flag.Parse()
+  if len(*accessToken) == 0 {
+    fmt.Println("You must specify --access_token")
+    os.Exit(1)
+  }
+
+  // Set up the LightStep tracer
+  tracerOpts := lightstep.Options{
+    AccessToken : *accessToken,
+  }
+  tracerOpts.Tags = make(opentracing.Tags)
+  tracerOpts.Tags["lightstep.component_name"] = "go.store-client"
+  tracer := lightstep.NewTracer(tracerOpts)
+
 	// Set up a connection to the server.
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
+	conn, err := grpc.Dial(
+    address, 
+    grpc.WithInsecure(),
+    grpc.WithUnaryInterceptor(
+      otgrpc.OpenTracingClientInterceptor(tracer)))
 	if err != nil {
 		log.Fatalf("did not connect: %v", err)
 	}
@@ -31,4 +58,10 @@ func main() {
 		log.Fatalf("could not get quantity: %v", err)
 	}
 	log.Printf("Quantity: %d", r.Quantity)
+
+  // Force a flush of the tracer
+  err = lightstep.FlushLightStepTracer(tracer)
+  if err != nil {
+    panic(err)
+  }
 }

--- a/example/go/client/main.go
+++ b/example/go/client/main.go
@@ -19,7 +19,8 @@ import (
 )
 
 const (
-	address = "localhost:50051"
+	address          = "localhost:50051"
+	ComponentNameKey = "lightstep.component_name"
 )
 
 var accessToken = flag.String("access_token", "", "your LightStep access token")
@@ -36,7 +37,7 @@ func main() {
 		AccessToken: *accessToken,
 	}
 	tracerOpts.Tags = make(opentracing.Tags)
-	tracerOpts.Tags["lightstep.component_name"] = "go.store-client"
+	tracerOpts.Tags[ComponentNameKey] = "go.store-client"
 	tracer := lightstep.NewTracer(tracerOpts)
 
 	// Set up a connection to the server.

--- a/example/go/run_client.sh
+++ b/example/go/run_client.sh
@@ -5,4 +5,4 @@ then
   exit -1
 fi
 export PYTHONPATH="../../py/"
-python store_server.py
+go run client/main.go --access_token $LIGHT_STEP_ACCESS_TOKEN

--- a/example/go/run_server.sh
+++ b/example/go/run_server.sh
@@ -5,4 +5,4 @@ then
   exit -1
 fi
 export PYTHONPATH="../../py/"
-python store_server.py
+go run server/main.go --access_token $LIGHT_STEP_ACCESS_TOKEN

--- a/example/go/server/main.go
+++ b/example/go/server/main.go
@@ -6,16 +6,25 @@ package main
 import (
 	"log"
 	"net"
+  "flag"
+  "fmt"
+  "os"
 
 	pb "../store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
+
+  "github.com/opentracing/opentracing-go"
+  "github.com/lightstep/lightstep-tracer-go"
+  "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
 )
 
 const (
 	port = ":50051"
 )
+
+var accessToken = flag.String("access_token", "", "your LightStep access token")
 
 // server is used to implement helloworld.StoreServer.
 type server struct{}
@@ -26,15 +35,36 @@ func (s *server) GetQuantity(ctx context.Context, in *pb.QuantityRequest) (*pb.Q
 }
 
 func main() {
+  flag.Parse()
+  if len(*accessToken) == 0 {
+    fmt.Println("You must specify --access_token")
+    os.Exit(1)
+  }
+
+  tracerOpts := lightstep.Options{
+    AccessToken : *accessToken,
+  }
+  tracerOpts.Tags = make(opentracing.Tags)
+  tracerOpts.Tags["lightstep.component_name"] = "go.store-server"
+  tracer := lightstep.NewTracer(tracerOpts)
+
+	// Set up a connection to the server.
 	lis, err := net.Listen("tcp", port)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	s := grpc.NewServer()
+	s := grpc.NewServer(grpc.UnaryInterceptor(
+    otgrpc.OpenTracingServerInterceptor(tracer)))
 	pb.RegisterStoreServer(s, &server{})
 	// Register reflection service on gRPC server.
 	reflection.Register(s)
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
+
+  // Force a flush of the tracer
+  err = lightstep.FlushLightStepTracer(tracer)
+  if err != nil {
+    panic(err)
+  }
 }

--- a/example/go/server/main.go
+++ b/example/go/server/main.go
@@ -4,20 +4,20 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"log"
 	"net"
-  "flag"
-  "fmt"
-  "os"
+	"os"
 
 	pb "../store"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
-  "github.com/opentracing/opentracing-go"
-  "github.com/lightstep/lightstep-tracer-go"
-  "github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/grpc-ecosystem/grpc-opentracing/go/otgrpc"
+	"github.com/lightstep/lightstep-tracer-go"
+	"github.com/opentracing/opentracing-go"
 )
 
 const (
@@ -35,18 +35,18 @@ func (s *server) GetQuantity(ctx context.Context, in *pb.QuantityRequest) (*pb.Q
 }
 
 func main() {
-  flag.Parse()
-  if len(*accessToken) == 0 {
-    fmt.Println("You must specify --access_token")
-    os.Exit(1)
-  }
+	flag.Parse()
+	if len(*accessToken) == 0 {
+		fmt.Println("You must specify --access_token")
+		os.Exit(1)
+	}
 
-  tracerOpts := lightstep.Options{
-    AccessToken : *accessToken,
-  }
-  tracerOpts.Tags = make(opentracing.Tags)
-  tracerOpts.Tags["lightstep.component_name"] = "go.store-server"
-  tracer := lightstep.NewTracer(tracerOpts)
+	tracerOpts := lightstep.Options{
+		AccessToken: *accessToken,
+	}
+	tracerOpts.Tags = make(opentracing.Tags)
+	tracerOpts.Tags["lightstep.component_name"] = "go.store-server"
+	tracer := lightstep.NewTracer(tracerOpts)
 
 	// Set up a connection to the server.
 	lis, err := net.Listen("tcp", port)
@@ -54,7 +54,7 @@ func main() {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	s := grpc.NewServer(grpc.UnaryInterceptor(
-    otgrpc.OpenTracingServerInterceptor(tracer)))
+		otgrpc.OpenTracingServerInterceptor(tracer)))
 	pb.RegisterStoreServer(s, &server{})
 	// Register reflection service on gRPC server.
 	reflection.Register(s)
@@ -62,9 +62,9 @@ func main() {
 		log.Fatalf("failed to serve: %v", err)
 	}
 
-  // Force a flush of the tracer
-  err = lightstep.FlushLightStepTracer(tracer)
-  if err != nil {
-    panic(err)
-  }
+	// Force a flush of the tracer
+	err = lightstep.FlushLightStepTracer(tracer)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/example/go/server/main.go
+++ b/example/go/server/main.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	port = ":50051"
+	port             = ":50051"
+	ComponentNameKey = "lightstep.component_name"
 )
 
 var accessToken = flag.String("access_token", "", "your LightStep access token")
@@ -45,7 +46,7 @@ func main() {
 		AccessToken: *accessToken,
 	}
 	tracerOpts.Tags = make(opentracing.Tags)
-	tracerOpts.Tags["lightstep.component_name"] = "go.store-server"
+	tracerOpts.Tags[ComponentNameKey] = "go.store-server"
 	tracer := lightstep.NewTracer(tracerOpts)
 
 	// Set up a connection to the server.

--- a/example/py/run_client.sh
+++ b/example/py/run_client.sh
@@ -1,3 +1,8 @@
 #!/bin/sh
+if [ -z $LIGHT_STEP_ACCESS_TOKEN ]
+then
+  echo "LIGHT_STEP_ACCESS_TOKEN must be set"
+  exit -1
+fi
 export PYTHONPATH="../../py/"
-python store_client.py
+python store_client.py --access_token $LIGHT_STEP_ACCESS_TOKEN

--- a/example/py/run_server.sh
+++ b/example/py/run_server.sh
@@ -5,4 +5,4 @@ then
   exit -1
 fi
 export PYTHONPATH="../../py/"
-python store_server.py
+python store_server.py --access_token $LIGHT_STEP_ACCESS_TOKEN

--- a/example/py/store_client.py
+++ b/example/py/store_client.py
@@ -2,21 +2,33 @@
 from __future__ import print_function
 
 import grpc
+import sys
 
 import store_pb2
 from tracer_interceptor import OpenTracingClientInterceptor
 from interceptor_channel import InterceptorChannel
-from opentracing import Tracer
+import lightstep
+import argparse
 
 
 def run():
-    tracer = Tracer()
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--access_token', help='LightStep Access Token')
+    args = parser.parse_args()
+    if not args.access_token:
+        print('You must specify access_token')
+        sys.exit(-1)
+
+    tracer = lightstep.Tracer(component_name='python.store-client',
+                              access_token=args.access_token)
     tracer_interceptor = OpenTracingClientInterceptor(tracer)
     channel = grpc.insecure_channel('localhost:50051')
     channel = InterceptorChannel(channel, tracer_interceptor)
     stub = store_pb2.StoreStub(channel)
     response = stub.GetQuantity(store_pb2.QuantityRequest(item_id=51))
     print('Quantity: ' + str(response.quantity))
+
+    tracer.flush()
 
 
 if __name__ == '__main__':

--- a/example/py/store_server.py
+++ b/example/py/store_server.py
@@ -1,12 +1,15 @@
 # A OpenTraced server for a Python service that implements the store interface.
 from concurrent import futures
 import time
+import sys
 
 import grpc
 
 import store_pb2
 from tracer_interceptor import OpenTracingServerInterceptor
 from interceptor_server import InterceptorServer
+import lightstep
+import argparse
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
@@ -17,9 +20,18 @@ class Store(store_pb2.StoreServicer):
 
 
 def serve():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--access_token', help='LightStep Access Token')
+    args = parser.parse_args()
+    if not args.access_token:
+        print('You must specify access_token')
+        sys.exit(-1)
+
+    tracer = lightstep.Tracer(component_name='python.store-server',
+                              access_token=args.access_token)
     server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
 
-    tracer_interceptor = OpenTracingServerInterceptor()
+    tracer_interceptor = OpenTracingServerInterceptor(tracer)
     server = InterceptorServer(server, tracer_interceptor)
 
     store_pb2.add_StoreServicer_to_server(Store(), server)
@@ -30,6 +42,8 @@ def serve():
             time.sleep(_ONE_DAY_IN_SECONDS)
     except KeyboardInterrupt:
         server.stop(0)
+
+    tracer.flush()
 
 if __name__ == '__main__':
     serve()

--- a/example/py/store_server.py
+++ b/example/py/store_server.py
@@ -5,26 +5,31 @@ import time
 import grpc
 
 import store_pb2
+from tracer_interceptor import OpenTracingServerInterceptor
+from interceptor_server import InterceptorServer
 
 _ONE_DAY_IN_SECONDS = 60 * 60 * 24
 
 
 class Store(store_pb2.StoreServicer):
-
-  def GetQuantity(self, request, context):
-    return store_pb2.QuantityResponse(quantity=301)
+    def GetQuantity(self, request, context):
+        return store_pb2.QuantityResponse(quantity=301)
 
 
 def serve():
-  server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
-  store_pb2.add_StoreServicer_to_server(Store(), server)
-  server.add_insecure_port('[::]:50051')
-  server.start()
-  try:
-    while True:
-      time.sleep(_ONE_DAY_IN_SECONDS)
-  except KeyboardInterrupt:
-    server.stop(0)
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+
+    tracer_interceptor = OpenTracingServerInterceptor()
+    server = InterceptorServer(server, tracer_interceptor)
+
+    store_pb2.add_StoreServicer_to_server(Store(), server)
+    server.add_insecure_port('[::]:50051')
+    server.start()
+    try:
+        while True:
+            time.sleep(_ONE_DAY_IN_SECONDS)
+    except KeyboardInterrupt:
+        server.stop(0)
 
 if __name__ == '__main__':
-  serve()
+    serve()

--- a/py/interceptor_server.py
+++ b/py/interceptor_server.py
@@ -1,0 +1,84 @@
+# An implementation for server-side interceptors for gRPC Python.
+# The plan is to eventually check in this code somewhere in the gRPC source as
+# a PR for https://github.com/grpc/grpc/issues/8767
+
+import grpc
+
+
+class InterceptorRpcMethodHandler(grpc.RpcMethodHandler):
+    def __init__(self, rpc_method_handler, interceptor):
+        self.rpc_method_handler = rpc_method_handler
+        self.interceptor = interceptor
+
+    @property
+    def request_streaming(self):
+        return self.rpc_method_handler.request_streaming
+
+    @property
+    def response_streaming(self):
+        return self.rpc_method_handler.response_streaming
+
+    @property
+    def request_deserializer(self):
+        return self.rpc_method_handler.request_deserializer
+
+    @property
+    def response_serializer(self):
+        return self.rpc_method_handler.response_serializer
+
+    @property
+    def unary_unary(self):
+        def adaptation(request, servicer_context):
+            def invoker(request, servicer_context):
+                return self.rpc_method_handler.unary_unary(request,
+                                                           servicer_context)
+            return self.interceptor(request, servicer_context, invoker)
+        return adaptation
+
+    @property
+    def unary_stream(self):
+        return self.rpc_method_handler.unary_stream
+
+    @property
+    def stream_unary(self):
+        return self.rpc_method_handler.stream_unary
+
+    @property
+    def stream_stream(self):
+        return self.rpc_method_handler.stream_stream
+
+
+class InterceptorGenericRpcHandler(grpc.GenericRpcHandler):
+    def __init__(self, generic_rpc_handler, interceptor):
+        self.generic_rpc_handler = generic_rpc_handler
+        self.interceptor = interceptor
+
+    def service(self, *args, **kwargs):
+        result = self.generic_rpc_handler.service(*args, **kwargs)
+        if result:
+            result = InterceptorRpcMethodHandler(result, self.interceptor)
+        return result
+
+
+class InterceptorServer(grpc.Server):
+    def __init__(self, server, interceptor):
+        self.server = server
+        self.interceptor = interceptor
+
+    def add_generic_rpc_handlers(self, generic_rpc_handlers):
+        generic_rpc_handlers = [
+          InterceptorGenericRpcHandler(generic_rpc_handler, self.interceptor)
+          for generic_rpc_handler in generic_rpc_handlers]
+        self.server.add_generic_rpc_handlers(generic_rpc_handlers)
+
+    def add_insecure_port(self, *args, **kwargs):
+        self.server.add_insecure_port(*args, **kwargs)
+
+    def add_secure_port(self, *args, **kwargs):
+        self.server.add_secure_port(*args, **kwargs)
+
+    def start(self):
+        self.server.start()
+
+    def stop(self, *args, **kwargs):
+        self.server.stop(*args, **kwargs)

--- a/py/tracer_interceptor.py
+++ b/py/tracer_interceptor.py
@@ -8,9 +8,7 @@ def inject_span_context(tracer, span_context, metadata):
     attributes = {}
     tracer.inject(span_context, opentracing.Format.HTTP_HEADERS, attributes)
     metadata = () if metadata is None else tuple(metadata)
-    span_metadata = tuple((key, value)
-                          for key, value in attributes.iteritems())
-    return metadata + span_metadata
+    return metadata + tuple(attributes.iteritems())
 
 
 class OpenTracingClientInterceptor(object):
@@ -26,7 +24,8 @@ class OpenTracingClientInterceptor(object):
 
 class OpenTracingServerInterceptor(object):
     def __call__(self, request, servicer_context, invoker):
-        print('before response')
+        print 'before response'
+        print 'metadata=' + str(servicer_context.invocation_metadata())
         response = invoker(request, servicer_context)
-        print('after response')
+        print 'after response'
         return response

--- a/py/tracer_interceptor.py
+++ b/py/tracer_interceptor.py
@@ -1,14 +1,15 @@
-import opentracing
 # Implementation for interceptors that implement open tracing. The plan is to
 # eventually check these into
 # https://github.com/grpc-ecosystem/grpc-opentracing
 
+import opentracing
+
 
 def inject_span_context(tracer, span_context, metadata):
-    attributes = {}
-    tracer.inject(span_context, opentracing.Format.HTTP_HEADERS, attributes)
+    headers = {}
+    tracer.inject(span_context, opentracing.Format.HTTP_HEADERS, headers)
     metadata = () if metadata is None else tuple(metadata)
-    return metadata + tuple(attributes.iteritems())
+    return metadata + tuple(headers.iteritems())
 
 
 class OpenTracingClientInterceptor(object):
@@ -22,10 +23,24 @@ class OpenTracingClientInterceptor(object):
             return invoker(request, metadata)
 
 
+def start_server_span(tracer, metadata, method):
+    span_context = None
+    tags = None
+    try:
+        if metadata:
+            span_context = tracer.extract(opentracing.Format.HTTP_HEADERS,
+                                          dict(metadata))
+    except (opentracing.InvalidCarrierException,
+            opentracing.SpanContextCorruptedException) as e:
+        tags = {'Extract failed': str(e)}
+    return tracer.start_span(operation_name=method, child_of=span_context,
+                             tags=tags)
+
+
 class OpenTracingServerInterceptor(object):
-    def __call__(self, request, servicer_context, invoker):
-        print 'before response'
-        print 'metadata=' + str(servicer_context.invocation_metadata())
-        response = invoker(request, servicer_context)
-        print 'after response'
-        return response
+    def __init__(self, tracer):
+        self.tracer = tracer
+
+    def __call__(self, request, metadata, server_info, handler):
+        with start_server_span(self.tracer, metadata, server_info.full_method):
+            return handler(request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+grpcio>=1.1.3
+grpcio-tools>=1.1.3


### PR DESCRIPTION
* Set up the examples to use LightStep's tracer.
* Modified the client-side tracer interceptor to propagate context in the metadata.
* Supported intercepting server-side unary-unary RPCs.
* Added a TODO list.